### PR TITLE
Add basic signal handler and graceful exit

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -4,10 +4,10 @@ import (
 	"log"
 	"sync"
 
-	goDaemon "github.com/sevlyar/go-daemon"
 	"github.com/psiayn/heiko/internal/config"
 	"github.com/psiayn/heiko/internal/daemon"
 	"github.com/psiayn/heiko/internal/scheduler"
+	goDaemon "github.com/sevlyar/go-daemon"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"log"
-	"syscall"
 
+	goDaemon "github.com/sevlyar/go-daemon"
 	"github.com/psiayn/heiko/internal/daemon"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var stopCmd = &cobra.Command{
@@ -13,13 +14,12 @@ var stopCmd = &cobra.Command{
 	Short: "Stops a running heiko daemon",
 	Run: func(cmd *cobra.Command, args []string) {
 		context := daemon.GetContext()
+
 		// searching if daemon exists
 		process, err := context.Search()
 		if err != nil {
-			log.Fatalln(err)
+			log.Fatalf("Could not find daemon %s: %v", viper.GetString("name"), err)
 		}
-		process.Signal(syscall.SIGTERM)
-		defer context.Release()
-
+		goDaemon.SendCommands(process)
 	},
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -20,6 +20,9 @@ var stopCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Could not find daemon %s: %v", viper.GetString("name"), err)
 		}
-		goDaemon.SendCommands(process)
+		err = goDaemon.SendCommands(process)
+		if err != nil {
+			log.Fatalf("Could not stop daemon %s: %v", viper.GetString("name"), err)
+		}
 	},
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"log"
 
-	goDaemon "github.com/sevlyar/go-daemon"
 	"github.com/psiayn/heiko/internal/daemon"
+	goDaemon "github.com/sevlyar/go-daemon"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"path/filepath"
+	"syscall"
 
 	"github.com/sevlyar/go-daemon"
 	"github.com/spf13/viper"
@@ -11,6 +12,8 @@ import (
 //  based on the program name
 //  (which is taken from viper)
 func GetContext() *daemon.Context {
+	SetHandlers(true)
+
 	// by default this is ~/.heiko/<name>
 	workDir := filepath.Join(
 		viper.GetString("dataLocation"),
@@ -42,4 +45,10 @@ func GetContext() *daemon.Context {
 	}
 
 	return context
+}
+
+// sets up signal handlers as in the example
+// given in https://github.com/sevlyar/go-daemon/blob/3fdf7dcbb9d92331eaa91e649c4755da76c64382/examples/cmd/gd-signal-handling/signal-handling.go#L21
+func SetHandlers(quit bool) {
+	daemon.AddCommand(daemon.BoolFlag(&quit), syscall.SIGINT, stopHandler)
 }

--- a/internal/daemon/handlers.go
+++ b/internal/daemon/handlers.go
@@ -1,0 +1,25 @@
+package daemon
+
+import (
+	"log"
+	"os"
+
+	"github.com/psiayn/heiko/internal/scheduler"
+	"github.com/sevlyar/go-daemon"
+)
+
+func stopHandler(sig os.Signal) error {
+	log.Println("Terminating heiko daemon...")
+
+	log.Println("Waiting for tasks to finish.")
+	for _, stop := range scheduler.Stops {
+		stop <- struct{}{}
+	}
+
+	log.Println("Waiting for scheduler to stop.")
+	for _, done := range scheduler.Dones {
+		<-done
+	}
+
+	return daemon.ErrStop
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -17,25 +17,26 @@ const Timeout = 2
 // these channels (one for each running scheduler) tell the scheduler to exit.
 //   when you pass a struct{}{} to this channel, the scheduler(s) exits
 var Stops = make([]chan struct{}, 0)
+
 // these channels are used to signal that the scheduler exited,
 //   this is to ensure that any cleanup required by the scheduler is done.
 //   the scheduler sends a struct{}{} over this channel when exiting
 var Dones = make([]chan struct{}, 0)
-// more about this empty struct: https://dave.cheney.net/2014/03/25/the-empty-struct
 
+// more about this empty struct: https://dave.cheney.net/2014/03/25/the-empty-struct
 
 func RandomScheduler(tasks chan config.Task, stop chan struct{}, done chan struct{}, nodes []config.Node, wg *sync.WaitGroup) {
 	rand.Seed(time.Now().Unix())
 
-// this is a label for the loop below
-//  we use this because using a "break"
-//  inside the switch statement will only
-//  break from the switch and not the loop
-//  more info: https://forum.golangbridge.org/t/is-using-continue-label-or-break-label-good-practice/8345
+	// this is a label for the loop below
+	//  we use this because using a "break"
+	//  inside the switch statement will only
+	//  break from the switch and not the loop
+	//  more info: https://forum.golangbridge.org/t/is-using-continue-label-or-break-label-good-practice/8345
 LOOP:
 	for {
 		select {
-		case task := <-tasks:  // got a new task
+		case task := <-tasks: // got a new task
 			go func() {
 				node := nodes[rand.Intn(len(nodes))]
 				log.Printf("Running task %s on node %s", task.Name, node.Name)
@@ -53,7 +54,7 @@ LOOP:
 				wg.Done()
 			}()
 
-			case <-stop:  // got the signal to stop :(
+		case <-stop: // got the signal to stop :(
 
 			// wait for tasks to finish using the wg
 			// a signal is sent on ch when they finish
@@ -63,24 +64,24 @@ LOOP:
 				close(ch)
 			}()
 
-			DRAIN:
+		DRAIN:
 			for {
-					select {
-					case <-tasks:
-						// tasks remaining in the queue are drained
-						//  and marked as done
-						wg.Done()
+				select {
+				case <-tasks:
+					// tasks remaining in the queue are drained
+					//  and marked as done
+					wg.Done()
 
-					case <-time.After(time.Second*Timeout):
-						// after timeout, just stop. existing connections will break.
-						log.Println("Stopping scheduler after timeout, some tasks were still executing")
-						break DRAIN
+				case <-time.After(time.Second * Timeout):
+					// after timeout, just stop. existing connections will break.
+					log.Println("Stopping scheduler after timeout, some tasks were still executing")
+					break DRAIN
 
-					case <-ch:
-						// all done. clean exit.
-						log.Println("All running tasks finished execution")
-						break DRAIN
-					}
+				case <-ch:
+					// all done. clean exit.
+					log.Println("All running tasks finished execution")
+					break DRAIN
+				}
 			}
 
 			break LOOP

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -52,10 +52,10 @@ LOOP:
 
 			case <-stop:  // got the signal to stop :(
 
-			// only exit once all tasks are done.
-			//   this is needed because the tasks run in separate goroutines
-			// TODO: this will block for commands that never exit. Ex: `cat`
-			wg.Wait()
+			// breaks out of the loop
+			// this means that the goroutines run above are not waited for
+			//   so, when the daemon exits the SSH connections are broken
+			//   with no chance for graceful exit
 
 			break LOOP
 		}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -11,23 +11,56 @@ import (
 	"time"
 )
 
-func RandomScheduler(tasks chan config.Task, nodes []config.Node, wg *sync.WaitGroup) {
+// these channels (one for each running scheduler) tell the scheduler to exit.
+//   when you pass a struct{}{} to this channel, the scheduler(s) exits
+var Stops = make([]chan struct{}, 0)
+// these channels are used to signal that the scheduler exited,
+//   this is to ensure that any cleanup required by the scheduler is done.
+//   the scheduler sends a struct{}{} over this channel when exiting
+var Dones = make([]chan struct{}, 0)
+// more about this empty struct: https://dave.cheney.net/2014/03/25/the-empty-struct
+
+
+func RandomScheduler(tasks chan config.Task, stop chan struct{}, done chan struct{}, nodes []config.Node, wg *sync.WaitGroup) {
 	rand.Seed(time.Now().Unix())
+
+// this is a label for the loop below
+//  we use this because using a "break"
+//  inside the switch statement will only
+//  break from the switch and not the loop
+//  more info: https://forum.golangbridge.org/t/is-using-continue-label-or-break-label-good-practice/8345
+LOOP:
 	for {
-		task := <-tasks
-		go func() {
-			node := nodes[rand.Intn(len(nodes))]
-			log.Printf("Running task %s on node %s", task.Name, node.Name)
+		select {
+		case task := <-tasks:  // got a new task
+			go func() {
+				node := nodes[rand.Intn(len(nodes))]
+				log.Printf("Running task %s on node %s", task.Name, node.Name)
 
-			err := connection.RunTask(node, task.Name, task.Commands)
+				err := connection.RunTask(node, task.Name, task.Commands)
 
-			// if command errored out or is set to Restart, try running it again
-			if err != nil || task.Restart {
-				tasks <- task
-				wg.Add(1)
-			}
+				// if command errored out or is set to Restart, try running it again
+				if err != nil || task.Restart {
+					tasks <- task
+					wg.Add(1)
+				}
 
-			wg.Done()
-		}()
+				log.Printf("Task %s completed on node %s", task.Name, node.Name)
+
+				wg.Done()
+			}()
+
+			case <-stop:  // got the signal to stop :(
+
+			// only exit once all tasks are done.
+			//   this is needed because the tasks run in separate goroutines
+			// TODO: this will block for commands that never exit. Ex: `cat`
+			wg.Wait()
+
+			break LOOP
+		}
 	}
+
+	// signal that this scheduler is exiting
+	done <- struct{}{}
 }


### PR DESCRIPTION
Fixes #1 

## Changes

 - Added a signal handler for SIGINT based on the [example](https://github.com/sevlyar/go-daemon/blob/master/examples/cmd/gd-signal-handling/signal-handling.go) in `go-daemon`
    - this ensures that the PID file is deleted
 - Gracefully exit scheduler based on a signal channel (called `stop`)
   - Update: the actual commands are not given a chance for graceful exit, the SSH connections get broken when the daemon exits
   - Update 2: graceful exit is again possible (see 504e7ce), this time with a timeout (default 2s) to ensure that it's not stuck stopping
 - Another signal channel (called `done`) to know when a scheduler exits after
   handling all cleanups
 - In summary: when you do `heiko stop`, heiko signals the schedulers (currently only 1) to exit, waits for them to cleanup and exit, exits the daemon while cleaning up the PID file.

## Bugs

See 8564bd8

~~Need to fix this before merging.~~

 - ~~If a non-exiting task (like `cat`) is running, heiko never~~
   ~~exits as the scheduler keeps waiting for the process to complete xD~~
    - ~~to test it without this bug, either remove that job from the config or comment out lines 19-21 in `internal/daemon/handlers.go`.~~
    - ~~perhaps we need to use context and timeout as described in this [SO answer](https://stackoverflow.com/a/58308642/11199009)~~