### PR TITLE
Replace tilde at the beginning of the node.Auth.Keys.Path #9

### DIFF
--- a/internal/config/sshSetup.go
+++ b/internal/config/sshSetup.go
@@ -107,6 +107,9 @@ func SetAuth(configuration *Config) error {
 
 		default:
 			// Set custom key if specified
+			if strings.HasPrefix(node.Auth.Keys.Path, "~") {
+				node.Auth.Keys.Path = strings.Replace(node.Auth.Keys.Path, "~", homePath, 1)
+			}
 			if node.Auth.Keys.Path != "" {
 				publicKeyPath = node.Auth.Keys.Path + ".pub"
 				privateKeyPath = node.Auth.Keys.Path

--- a/internal/connection/establish_connection.go
+++ b/internal/connection/establish_connection.go
@@ -22,6 +22,14 @@ func publicKey(path string) []ssh.AuthMethod {
 		path = filepath.Join(home, ".ssh/heiko/key")
 	}
 
+	if strings.HasPrefix(path, "~") {
+		homePath, err := os.UserHomeDir()
+		if err != nil {
+			return []ssh.AuthMethod{}
+		}
+		path = strings.Replace(path, "~", homePath, 1)
+	}
+
 	key, err := ioutil.ReadFile(path)
 	if err != nil {
 		return []ssh.AuthMethod{}


### PR DESCRIPTION
Fixes #9 

Replace tilde at the beginning of the node.Auth.Keys.Path